### PR TITLE
Fix build workflow and Docker config

### DIFF
--- a/.github/workflows/docker-ci-cd.yml
+++ b/.github/workflows/docker-ci-cd.yml
@@ -25,19 +25,25 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Get version
+        id: version
+        run: echo "version=$(node -p 'require(\"./package.json\").version')" >> $GITHUB_OUTPUT
+
+      - name: Extract metadata (labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/prompthub
-
+          
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/prompthub:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/prompthub:latest
           labels: ${{ steps.meta.outputs.labels }}
 
       # - name: Deploy to server (optional)

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -2,7 +2,7 @@
 #
 # To get started with Next.js see: https://nextjs.org/docs/getting-started
 #
-name: Deploy Next.js site to Pages
+name: Next.js CI
 
 on:
   # Runs on pushes targeting the default branch
@@ -15,14 +15,8 @@ on:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
+
 
 jobs:
   # Build job
@@ -53,14 +47,6 @@ jobs:
         with:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-        with:
-          # Automatically inject basePath in your Next.js configuration file and disable
-          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
-          #
-          # You may remove this line if you want to manage the configuration yourself.
-          static_site_generator: next
       - name: Restore cache
         uses: actions/cache@v4
         with:
@@ -75,19 +61,4 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./out
 
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -30,3 +30,15 @@ bun dev
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+
+## Docker Image
+
+The GitHub Actions workflow builds a Docker image and publishes it to the
+[GitHub Container Registry](https://ghcr.io). Each build is tagged with the
+semantic version from `package.json` as well as `latest`.
+
+You can pull the image using:
+
+```bash
+docker pull ghcr.io/<your-org>/prompthub:<version>
+```

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Generate a standalone output for use with Node.js servers
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- remove GitHub Pages deployment step from workflow
- adjust permissions and caching in the CI workflow
- enable standalone build in `next.config.ts`
- build Docker image on CI and push to GHCR using version from package.json
- document Docker image usage

## Testing
- `npm run lint` *(fails: next not found)*