### PR TITLE
Add shared prompt schema and JSON share endpoint

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 PromptHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,13 @@ Pull the image using:
 ```bash
 docker pull ghcr.io/<your-org>/prompthub:<version>
 ```
+
+### Share a Prompt
+
+Each saved prompt provides a **Share JSON** option. This copies a link like
+`https://<host>/api/prompt/<id>/share` that returns the prompt data in JSON
+format.
+
+## License
+
+PromptHub is released under the [MIT License](LICENSE).

--- a/src/app/api/prompt/[id]/share/route.ts
+++ b/src/app/api/prompt/[id]/share/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/firebase';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request, context: any) {
+  if (!db) {
+    console.warn('Firebase is not initialized - running in build mode');
+    return NextResponse.json(
+      { error: 'Service temporarily unavailable' },
+      { status: 503, headers: { 'Retry-After': '60', 'Cache-Control': 'no-store' } }
+    );
+  }
+
+  const { id } = await context.params;
+  if (!id) {
+    return NextResponse.json(
+      { error: 'Prompt ID is required' },
+      { status: 400, headers: { 'Cache-Control': 'no-store' } }
+    );
+  }
+
+  try {
+    const promptDoc = await db.collection('prompts').doc(id).get();
+    if (!promptDoc.exists) {
+      return NextResponse.json(
+        { error: 'Prompt not found' },
+        { status: 404, headers: { 'Cache-Control': 'no-store' } }
+      );
+    }
+
+    const promptData = promptDoc.data();
+    return NextResponse.json(
+      { id: promptDoc.id, ...promptData },
+      { headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300' } }
+    );
+  } catch (error) {
+    console.error('Error fetching prompt share:', error);
+    return NextResponse.json(
+      { error: 'Failed to retrieve prompt data' },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } }
+    );
+  }
+}

--- a/src/app/api/prompts/anonymous/route.ts
+++ b/src/app/api/prompts/anonymous/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/firebase';
 import { v4 as uuidv4 } from 'uuid';
+import { validatePrompt } from '@/lib/prompt-schema';
 
 export const dynamic = 'force-dynamic';
 
@@ -18,7 +19,7 @@ export async function POST(request: Request) {
     const data = await request.json();
 
     // Validate required fields
-    if (!data.title || !data.content) {
+    if (!validatePrompt(data)) {
       return NextResponse.json(
         { error: 'Title and content are required' },
         { status: 400 }

--- a/src/app/api/prompts/route.ts
+++ b/src/app/api/prompts/route.ts
@@ -4,20 +4,13 @@ import {getServerSession} from 'next-auth/next';
 import {authOptions} from '@/lib/auth';
 import {v4 as uuidv4} from 'uuid';
 import {CollectionReference, Query} from 'firebase-admin/firestore';
+import type { Prompt } from '@/lib/prompt-schema';
+import { validatePrompt } from '@/lib/prompt-schema';
 
 export const dynamic = "force-dynamic";
 
 const ITEMS_PER_PAGE = 12; // Number of items per page
 
-// Define interface for prompt document data
-interface PromptDocument {
-  id: string;
-  createdAt: any; // Use more specific type if available (e.g., FirebaseFirestore.Timestamp)
-  likes?: number;
-
-  // Add other fields that exist in your document
-  [key: string]: any; // Allow other properties
-}
 
 export async function GET(request: Request) {
   // Return empty array if Firebase is not initialized (build time)
@@ -92,7 +85,7 @@ export async function GET(request: Request) {
     let items = filteredDocs.map(doc => ({
       id: doc.id,
       ...doc.data()
-    })) as PromptDocument[];
+    })) as Prompt[];
     
     // Apply sorting in memory
     switch (sortBy) {
@@ -146,8 +139,7 @@ export async function POST(request: Request) {
     const session = await getServerSession(authOptions);
     const data = await request.json();
 
-    // Validate required fields
-    if (!data.title || !data.content) {
+    if (!validatePrompt(data)) {
       return NextResponse.json(
         { error: 'Title and content are required' },
         { status: 400 }

--- a/src/app/api/prompts/submit/route.ts
+++ b/src/app/api/prompts/submit/route.ts
@@ -3,6 +3,7 @@ import { db } from '@/lib/firebase';
 import { getServerSession } from 'next-auth/next';
 import { v4 as uuidv4 } from 'uuid';
 import { authOptions } from '@/lib/auth';
+import { validatePrompt } from '@/lib/prompt-schema';
 
 export async function POST(request: NextRequest) {
   try {
@@ -14,12 +15,11 @@ export async function POST(request: NextRequest) {
     }
 
     // Parse request body
-    const data = await request.json();
+  const data = await request.json();
 
-    // Validate required fields
-    if (!data.title || !data.content) {
-      return NextResponse.json({ error: 'Title and content are required' }, { status: 400 });
-    }
+  if (!validatePrompt(data)) {
+    return NextResponse.json({ error: 'Title and content are required' }, { status: 400 });
+  }
 
     // Create a new prompt document
     const promptData = {

--- a/src/app/api/prompts/user/route.ts
+++ b/src/app/api/prompts/user/route.ts
@@ -2,22 +2,11 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/firebase';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/lib/auth';
+import type { Prompt } from '@/lib/prompt-schema';
 
 export const dynamic = "force-dynamic";
 
 // Define interface for prompt data
-interface Prompt {
-    id: string;
-    author?: string;
-    user_id?: string;
-    title?: string;
-    content?: string;
-    createdAt?: {
-        seconds: number;
-        nanoseconds: number;
-    };
-    [key: string]: any; // For any other fields
-}
 
 export async function GET() {
     try {

--- a/src/components/contribute/PromptActions.tsx
+++ b/src/components/contribute/PromptActions.tsx
@@ -121,6 +121,21 @@ export default function PromptActions({
     }
   };
 
+  const handleShareJson = () => {
+    if (!promptId) {
+      showNotification('error', t('prompt.save-before-share'));
+      return;
+    }
+
+    const url = `${window.location.origin}/api/prompt/${promptId}/share`;
+    navigator.clipboard
+      .writeText(url)
+      .then(() => {
+        showNotification('success', t('prompt.link-copied'));
+      })
+      .catch(console.error);
+  };
+
   const buttonClass = "flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500";
   const iconClass = 'h-4 w-4';
 
@@ -170,6 +185,18 @@ export default function PromptActions({
           >
             <ShareIcon className={iconClass} />
             <span className="hidden sm:inline">{t('prompt.share')}</span>
+          </button>
+        )}
+
+        {promptId && (
+          <button
+            type="button"
+            onClick={handleShareJson}
+            className={buttonClass}
+            aria-label={t('prompt.share-json')}
+          >
+            <ShareIcon className={iconClass} />
+            <span className="hidden sm:inline">{t('prompt.share-json')}</span>
           </button>
         )}
       </div>

--- a/src/context/locales/en.ts
+++ b/src/context/locales/en.ts
@@ -63,6 +63,7 @@ const en = {
   'prompt.exported': 'Prompt exported successfully!',
   'prompt.export-failed': 'Failed to export prompt',
   'prompt.share': 'Share',
+  'prompt.share-json': 'Share JSON',
   'prompt.link-copied': 'Link copied to clipboard!',
   'prompt.save-before-share': 'Please save the prompt before sharing',
   'prompt.likes': 'Likes',

--- a/src/context/locales/fa.ts
+++ b/src/context/locales/fa.ts
@@ -63,6 +63,7 @@ const fa = {
   'prompt.exported': 'پرامپت با موفقیت ذخیره شد!',
   'prompt.export-failed': 'خطا در ذخیره‌سازی پرامپت',
   'prompt.share': 'اشتراک‌گذاری',
+  'prompt.share-json': 'اشتراک JSON',
   'prompt.link-copied': 'لینک در کلیپ‌بورد کپی شد!',
   'prompt.save-before-share': 'لطفاً قبل از اشتراک‌گذاری، پرامپت را ذخیره کنید',
   'prompt.likes': 'پسند',

--- a/src/lib/prompt-data.ts
+++ b/src/lib/prompt-data.ts
@@ -1,30 +1,12 @@
-// Define the types for prompts and their details
+// Prompt type definitions shared across the app
 export type PromptTag = string;
 export type PromptCategory = string;
 export type PromptUseCase = string;
 
-export type PromptDetail = {
-  id: string;
-  title: string;
-  content: string;
-  useCases: PromptUseCase[];
-  category: PromptCategory;
-  tags: PromptTag[] | string;
-  author: string;
-  likes: number;
-  copies: number;
-  createdAt?: string | FirebaseFirestore.Timestamp;
-  updatedAt?: string | FirebaseFirestore.Timestamp;
-  searchTerms?: string[];
-  // Additional fields for the contribute page
-  model?: string;
-  promptType?: string;
-  complexityLevel?: string;
-  example?: string;
-  tips?: string;
-  expectedResponse?: string;
-  isAnonymous?: boolean;
-};
+import type { Prompt } from './prompt-schema';
+
+// Backwards compatibility for existing imports
+export type PromptDetail = Prompt;
 
 export type PaginatedResponse<T> = {
   items: T[];

--- a/src/lib/prompt-schema.ts
+++ b/src/lib/prompt-schema.ts
@@ -1,0 +1,34 @@
+export interface Prompt {
+  id: string;
+  title: string;
+  content: string;
+  description?: string;
+  useCases?: string[];
+  category?: string;
+  tags?: string[] | string;
+  author?: string;
+  user_id?: string;
+  user_details?: {
+    email: string | null;
+    name: string | null;
+    image: string | null;
+  };
+  isAnonymous?: boolean;
+  likes?: number;
+  copies?: number;
+  createdAt?: any;
+  updatedAt?: any;
+  searchTerms?: string[];
+  model?: string;
+  promptType?: string;
+  complexityLevel?: string;
+  example?: string;
+  tips?: string;
+  expectedResponse?: string;
+}
+
+export type PromptInput = Omit<Prompt, 'id' | 'likes' | 'copies' | 'createdAt' | 'updatedAt'>;
+
+export function validatePrompt(data: any): data is PromptInput {
+  return typeof data?.title === 'string' && typeof data?.content === 'string';
+}


### PR DESCRIPTION
## Summary
- add MIT license
- introduce unified prompt schema and validation helpers
- share prompts via `/api/prompt/[id]/share` endpoint
- add share JSON action in prompt contributor UI
- localize new button text
- document sharing and license in README

## Testing
- `npm run lint` *(fails: next not installed)*